### PR TITLE
fix: allow pointer events for disabled inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # coolify-tweaks
 
+## 3.5.3
+
+### Patch Changes
+
+- fix: allow pointer events for disabled inputs
+
 ## 3.5.2
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coolify-tweaks",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "description": "Opinionated tweaks for Coolify: better spacing, layout, and color polish.",
   "author": {
     "name": "Anirudh Sriram",

--- a/src/components/ui/_input.scss
+++ b/src/components/ui/_input.scss
@@ -53,7 +53,7 @@
   }
 
   &:disabled {
-    pointer-events: none;
+    pointer-events: all;
     cursor: not-allowed;
     opacity: 0.5 !important;
   }


### PR DESCRIPTION
The files in the `Dynamic Configurations` section of the `Proxy` configuration in Coolify couldn't be scrolled before this change.