### PR TITLE
fix: make "Maybe next time" text visible in light mode for sponsor prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # coolify-tweaks
 
+## 3.8.4
+
+### Patch Changes
+
+- fix: make "Maybe next time" text visible in light mode
+
 ## 3.8.3
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coolify-tweaks",
-  "version": "3.8.3",
+  "version": "3.8.4",
   "description": "Opinionated tweaks for Coolify: better spacing, layout, and color polish.",
   "author": {
     "name": "Anirudh Sriram",

--- a/src/theme/_variables.scss
+++ b/src/theme/_variables.scss
@@ -110,6 +110,7 @@ $breakpoints: (
   --shadow-xl: 0px 2px 3px 0px hsl(0 0% 0% / 0.16), 0px 8px 10px -1px hsl(0 0% 0% / 0.16);
   --shadow-2xl: 0px 2px 3px 0px hsl(0 0% 0% / 0.4);
 }
+
 /* ==UI-THEME-VARS:END== */
 
 // Color variables for success, warning, and info states
@@ -141,7 +142,7 @@ $breakpoints: (
   --sidebar-width: 260px;
   --blur: 10px;
 
-  --color-base: var(--background);
+  --color-base: var(--foreground);
   --color-coollabs: var(--primary);
   --color-text-primary: var(--foreground);
 


### PR DESCRIPTION
<img width="794" height="199" alt="image" src="https://github.com/user-attachments/assets/6fa2cc2c-c1d7-4fc3-9a44-4dd973cd36a5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed visibility of "Maybe next time" text in light mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->