### PR TITLE
 Keep “unmask” button functional for disabled inputs

### DIFF
--- a/apps/style/src/components/ui/_input.scss
+++ b/apps/style/src/components/ui/_input.scss
@@ -58,7 +58,6 @@
   }
 
   &:disabled {
-    pointer-events: all;
     cursor: not-allowed;
     opacity: 0.5;
   }
@@ -67,6 +66,28 @@
     background: var(--primary);
     color: var(--primary-foreground);
   }
+}
+
+/* Keep password/visibility toggles clickable when input is disabled (clean, grouped selectors) */
+/* Siblings of a disabled input (typical toggle button next to input) */
+:where(input:disabled, input[disabled]) ~ :is(button:not(:disabled), [role="button"], [x-on\:click], [\@click]) {
+  pointer-events: auto !important;
+  cursor: pointer !important;
+  z-index: 2;
+}
+
+/* Controls inside a relative wrapper that contains a disabled input (absolute icons/toggles) */
+:where(div, label).relative:has(> :is(input:disabled, input[disabled])) :is(button:not(:disabled), [role="button"], [x-on\:click], [\@click]) {
+  pointer-events: auto !important;
+  cursor: pointer !important;
+  z-index: 2;
+}
+
+/* Entire fieldsets disabled but non-form controls should still be clickable */
+fieldset[disabled] :is(button:not(:disabled), [role="button"], [x-on\:click], [\@click]) {
+  pointer-events: auto !important;
+  cursor: pointer !important;
+  z-index: 2;
 }
 
 input.input,


### PR DESCRIPTION
## Summary
- Fixes a bug where the show/hide (unmask) control became non-interactive when its input was disabled. In the normal UI the unmask button worked normally

 ### Bug: 

https://github.com/user-attachments/assets/3cce6ede-e894-4b03-9ea0-d5cdc73e8d13
 
### Fix: 

https://github.com/user-attachments/assets/f44afe9e-a01e-4fd3-8b22-b86e06c977d0

Notes
- I mainly used AI to find the issue, so don't know if there is a better solution to this problem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled inputs are no longer clickable, matching expected behavior.
  * Ensured adjacent or related controls (e.g., buttons, role="button" elements, clickable icons) remain interactive even when nearby inputs or fieldsets are disabled.
  * Improved interaction within wrappers and fieldsets so associated controls are not blocked.
* **Style**
  * Updated cursors to indicate clickability for enabled controls near disabled inputs.
  * Adjusted stacking to prevent disabled elements from intercepting clicks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->