### PR TITLE
fix(docs): replace broken Twitter video with YouTube embed

### DIFF
--- a/apps/docs/content/docs/style/theming.mdx
+++ b/apps/docs/content/docs/style/theming.mdx
@@ -169,10 +169,7 @@ If you prefer watching instead, here's a short walkthrough:
 
 <VideoPlayer
   className="aspect-video w-full"
-  crossOrigin=""
-  muted
-  preload="auto"
-  src="https://video.twimg.com/amplify_video/1981595617622134784/vid/avc1/1280x720/K0GKgQkgCMTcERwQ.mp4"
+  src="youtube/FKx8WNyTXeM"
 />
 
 ## Tips

--- a/apps/docs/content/docs/style/theming.mdx
+++ b/apps/docs/content/docs/style/theming.mdx
@@ -169,7 +169,7 @@ If you prefer watching instead, here's a short walkthrough:
 
 <VideoPlayer
   className="aspect-video w-full"
-  src="youtube/FKx8WNyTXeM"
+  src="youtube/fexFxdE4jGE"
 />
 
 ## Tips


### PR DESCRIPTION
The theming video guide was returning 403 from video.twimg.com due to
Twitter blocking hotlinked video content. Switched to YouTube embed
using vidstack's native YouTube provider.

https://claude.ai/code/session_014CCAXWeN4boNw9SWToiuU4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the VideoPlayer component in the theming documentation with a simplified video source format and refined playback configuration for improved clarity in documentation examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->